### PR TITLE
Typo in customization keyword

### DIFF
--- a/auto-capitalize.el
+++ b/auto-capitalize.el
@@ -159,14 +159,14 @@ modified."
 In auto-capitalize mode, it is called with no arguments and should return a
 non-nil value if the current word is within \"normal\" text."
   :group 'auto-capitalize
-  :type '(choise (function :tag "Predicate function")
+  :type '(choice (function :tag "Predicate function")
                  (const nil)))
 
 (defcustom auto-capitalize-allowed-chars '(?\  ?, ?. ?? ?' ?’ ?: ?\; ?- ?!)
   "Whether auto capitalize after you typed those characters.
 If you set nil, then don't restrict by this variable."
   :group 'auto-capitalize
-  :type '(choise (repeat (character :tag "Characters to start"))
+  :type '(choice (repeat (character :tag "Characters to start"))
                  (const nil)))
 
 (defcustom auto-capitalize-inhibit-buffers '("*scratch*")
@@ -179,7 +179,7 @@ If you set nil, then don't restrict by this variable."
 The function should return t if the predicate is ok or
 return nil if it's failure."
   :group 'auto-capitalize
-  :type '(choise
+  :type '(choice
           (repeat (function :tag "Predicate functions"))
           (const nil)))
 
@@ -187,7 +187,7 @@ return nil if it's failure."
   "You can set a file path of aspell to use capitalized words of aspell.
 The file name would be something like .aspell.en.pws."
   :group 'auto-capitalize
-  :type '(choise
+  :type '(choice
           (const nil)
           (file)))
 


### PR DESCRIPTION
It breaks the customization interface.